### PR TITLE
Bug fixes to pulseOx code

### DIFF
--- a/physio/PulseResp.m
+++ b/physio/PulseResp.m
@@ -86,14 +86,18 @@ sig = FWHM/(2*(sqrt(2*log(2)))); % convert to sigma
 pulse.Lsignal = smooth_kernel(pulse.Lsignal,sig);
 %% Find the peaks
 %IF WANT TO USE DELTA must be divided by sampling period (in msec)
+delta.cardiac = 600./pulse.sampT; %sets max delta to reflect 100bpm
+delta.resp = 3000./pulse.sampT; %sets max delta to reflect 20 breaths/min
 %[pulse.highMax,pulse.highMin] = detpeaks(pulse.Hsignal,pulse.delta./pulse.sampT);
-[pulse.highMax,pulse.highMin] = detpeaks(pulse.Hsignal);
+%[pulse.highMax,pulse.highMin] = detpeaks(pulse.Hsignal);
+[pulse.highMax,pulse.highMin] = detpeaks(pulse.Hsignal,delta.cardiac);
 output.Hevents = zeros(size(pulse.Hsignal));
 if ~isempty(pulse.highMax)
     output.Hevents(pulse.highMax(:,1)) = 1;
 end
 %[pulse.lowMax,pulse.lowMin] = detpeaks(pulse.Lsignal,pulse.delta./pulse.sampT);
-[pulse.lowMax,pulse.lowMin] = detpeaks(pulse.Lsignal);
+%[pulse.lowMax,pulse.lowMin] = detpeaks(pulse.Lsignal);
+[pulse.lowMax,pulse.lowMin] = detpeaks(pulse.Lsignal,delta.resp);
 output.Levents = zeros(size(pulse.Lsignal));
 if ~isempty(pulse.lowMax)
     output.Levents(pulse.lowMax(:,1)) = 1;

--- a/physio/PulseResp.m
+++ b/physio/PulseResp.m
@@ -85,12 +85,15 @@ FWHM = 0.4*pulse.sampR; % % 400 ms FWHM; following Verstynen & Deshpande (2011)
 sig = FWHM/(2*(sqrt(2*log(2)))); % convert to sigma
 pulse.Lsignal = smooth_kernel(pulse.Lsignal,sig);
 %% Find the peaks
-[pulse.highMax,pulse.highMin] = detpeaks(pulse.Hsignal,pulse.delta);
+%IF WANT TO USE DELTA must be divided by sampling period (in msec)
+%[pulse.highMax,pulse.highMin] = detpeaks(pulse.Hsignal,pulse.delta./pulse.sampT);
+[pulse.highMax,pulse.highMin] = detpeaks(pulse.Hsignal);
 output.Hevents = zeros(size(pulse.Hsignal));
 if ~isempty(pulse.highMax)
     output.Hevents(pulse.highMax(:,1)) = 1;
 end
-[pulse.lowMax,pulse.lowMin] = detpeaks(pulse.Lsignal,pulse.delta);
+%[pulse.lowMax,pulse.lowMin] = detpeaks(pulse.Lsignal,pulse.delta./pulse.sampT);
+[pulse.lowMax,pulse.lowMin] = detpeaks(pulse.Lsignal);
 output.Levents = zeros(size(pulse.Lsignal));
 if ~isempty(pulse.lowMax)
     output.Levents(pulse.lowMax(:,1)) = 1;

--- a/physio/read_PULS_log_file.m
+++ b/physio/read_PULS_log_file.m
@@ -38,6 +38,10 @@ for i = 1:Nvalues
         isTrigger(i) = 0;
     elseif (b==4)
         pulse.data(i) = a(end - length('PULS_TRIGGER'));
+        pulse.AT_ms(i) = 2.5*a(1); % multiply by 2.5ms 'tics'
+        if pulse.AT_ms(i) > 86400000 % 24 hours = 24*60*60*1000
+            pulse.AT_ms(i) = pulse.AT_ms(i) - 86400000;
+        end
         isTrigger(i) = 1;
     end
 end

--- a/utilityFunctions/detpeaks.m
+++ b/utilityFunctions/detpeaks.m
@@ -6,7 +6,8 @@ function [trueMax, trueMin]=detpeaks(v,delta,showplot)
 %
 %   defaults:
 %   v = no default, must specify a vector
-%   delta = 30; % for heart rate, assumes 30 beats per minute
+%   delta = 120; % for heart rate, assumes 100 beats per minute at a 
+%   sampling period of 5ms. 
 %   showplot = 0; don't plot the max and min peaks on the vector
 %
 %   The delta values is based on the distance betwen peak indices. The
@@ -27,8 +28,8 @@ function [trueMax, trueMin]=detpeaks(v,delta,showplot)
 maxvals = [];
 minvals = [];
 v = v(:);
-if ~exist('delta','var')
-    delta = 30; % 100 beats / minute
+if ~exist('delta','var') || isnan(delta)
+    delta = 120; % 100 beats / minute 
 end
 if ~exist('showplot','var')
     showplot = 0; % don't plot


### PR DESCRIPTION
-read_PULS_log_file.m now accurately records peaks and heartrate delta
-PulseRes.m no longer passes delta to detpeaks.m but includes fixed code for doing so
-detpeaks.m default value for delta fixed to accurately reflect a heartrate of 100bpm at sampling period of 5ms and to default to default value if passed NaN, which can happen if passing delta computed from the log file and no pulse triggers were recorded